### PR TITLE
fix: update ld.lld and lld copy commands in release workflow to use -…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,11 +221,11 @@ jobs:
                   if [ "${{ runner.os }}" = "Linux" ]; then
                     # clang++ looks specifically for 'ld.lld' when given -fuse-ld=lld
                     if [ -f "$DEPS_BIN/ld.lld" ]; then
-                      cp -a "$DEPS_BIN/ld.lld" "$STAGED_BIN/"
+                      # -L to copy the actual binary, not the symlink!
+                      cp -L "$DEPS_BIN/ld.lld" "$STAGED_BIN/"
                       echo "Bundled ld.lld into SDK bin/"
                     elif [ -f "$DEPS_BIN/lld" ]; then
-                      # Fallback: copy lld but name it ld.lld to satisfy clang's search pattern
-                      cp -a "$DEPS_BIN/lld" "$STAGED_BIN/ld.lld"
+                      cp -L "$DEPS_BIN/lld" "$STAGED_BIN/ld.lld"
                       echo "Bundled lld (as ld.lld) into SDK bin/"
                     else
                       echo "ERROR: ld.lld or lld not found in deps — zero-dependency Linux AOT will fail."

--- a/src/compiler/Linker/LinkerCommandBuilder.cpp
+++ b/src/compiler/Linker/LinkerCommandBuilder.cpp
@@ -131,10 +131,7 @@ void LinkerCommandBuilder::addPlatformPreamble(std::vector<std::string> &args) {
     args.push_back("-Wl,-w");
   }
 #elif defined(__linux__)
-// Force Clang to use the bundled ld.lld sitting right next to it
-std::string clang_path = io::PathUtils::getAOTLinkerPath();
-std::filesystem::path lld_path = std::filesystem::path(clang_path).parent_path() / "ld.lld";
-args.push_back("--ld-path=\"" + lld_path.string() + "\"");
+args.push_back("-fuse-ld=lld");
 #elif defined(_WIN32)
   args.push_back("/nologo");
 #endif


### PR DESCRIPTION
…L option for accurate binary copying

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow to copy linker tool contents instead of preserving symlinks.
  * Modified linker configuration to use standardized driver flags for linker selection on Linux builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->